### PR TITLE
Add dependency info

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,15 @@ Rust wrapper to [MATLAB MAT file I/O library](https://github.com/tbeu/matio)
 
 This crate provides bindings and wrappers for [MATIO](https://github.com/tbeu/matio):
 MATLAB MAT file I/O C library
+
+# Dependencies
+
+- cmake
+- zlib
+
+## Install Dependencies on Debian
+
+```sh
+sudo apt install cmake zlib1g-dev
+```
+


### PR DESCRIPTION
I haven't done C++ on this machine before and when I tried to use matio-rs I ran into errors and am creating this PR to help the next person. I only have access to this machine right now so not sure what would be the best way to provide instructions for install on other operating systems. I felt that instructions for one OS was better than none even though it seemed kind of unfair. It would at least allow users to have something to start with when searching. Names for dependencies that I put in the readme was based on my understanding.

The install commands are based on my interpretation of the error messages and what I found when I did a Google search. Note that errors were very long and included file paths and so on but I've extracted what I think was the relevant part.

What I think was the relevant part of the first error was:

```
--- stderr
  thread 'main' panicked at '
  failed to execute command: No such file or directory (os error 2)
  is `cmake` not installed?
```

Command used to install dependency was `sudo apt install cmake` and found on https://learnubuntu.com/install-cmake/

The next error was 

```
note: /usr/bin/ld: cannot find -lz: No such file or directory
          collect2: error: ld returned 1 exit status
```

Command used to install dependency was `sudo apt-get install zlib1g-dev` and was taken from https://stackoverflow.com/questions/3373995/usr-bin-ld-cannot-find-lz



