### PR TITLE
Update FFI crate to support the latest Zlib on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 categories = ["api-bindings", "mathematics", "science"]
 
 [dependencies]
-ffi = { version = "0.2.5", path = "sys", package = "matio-rs-sys" }
+ffi = { version = "0.2.6", path = "sys", package = "matio-rs-sys" }
 paste = "1.0.15"
 thiserror = "2.0.18"
 derive = { version = "0.1.0", path = "derive", package = "matio-rs_derive" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matio-rs"
-version = "1.6.3"
+version = "1.6.4"
 edition = "2024"
 authors = ["Rod Conan <rconan@gmto.org>"]
 license = "MIT"

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matio-rs-sys"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 authors = ["Rod Conan <rconan@gmto.org>"]
 license = "MIT"

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -21,7 +21,7 @@ fn main() {
         } else {
             panic!("ZLIB_LIB_DIR environment variable not set");
         }
-        println!("cargo:rustc-link-lib=zlib");
+        println!("cargo:rustc-link-lib=z");
     } else {
         println!("cargo:rustc-link-lib=matio");
         println!("cargo:rustc-link-lib=z");


### PR DESCRIPTION
Thank you for the awesome crate!

I would like to propose updating the `matio-rs-sys` to support the latest Zlib `1.3.2` that is supplied via [`vcpkg`](https://github.com/microsoft/vcpkg/blob/master/ports/zlib/portfile.cmake) - now on Windows we also have `z.dll` and `z.lib` instead of `zlib.lib` and `zlib.dll`.