### PR TITLE
Fix character arrays handling

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,9 +17,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        
+
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: recursive
 
@@ -32,8 +32,8 @@ jobs:
         .\vcpkg\vcpkg.exe install zlib:x64-windows-static
         $libDir = "${{ github.workspace }}\vcpkg\installed\x64-windows-static\lib"
         $dbgDir = "${{ github.workspace }}\vcpkg\installed\x64-windows-static\debug\lib"
-        Copy-Item "$libDir\zs.lib" "$libDir\zlib.lib"
-        Copy-Item "$dbgDir\zsd.lib" "$dbgDir\zlib.lib"
+        Copy-Item "$libDir\zs.lib" "$libDir\z.lib"
+        Copy-Item "$dbgDir\zsd.lib" "$dbgDir\z.lib"
         $includeDir = "${{ github.workspace }}\vcpkg\installed\x64-windows-static\include"
         echo "ZLIB_LIB_DIR=$libDir" >> $env:GITHUB_ENV
         echo "ZLIB_INCLUDE_DIR=$includeDir" >> $env:GITHUB_ENV

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matio-rs"
-version = "1.6.4"
+version = "1.6.5"
 edition = "2024"
 authors = ["Rod Conan <rconan@gmto.org>"]
 license = "MIT"
@@ -11,7 +11,7 @@ readme = "README.md"
 categories = ["api-bindings", "mathematics", "science"]
 
 [dependencies]
-ffi = { version = "0.2.6", path = "sys", package = "matio-rs-sys" }
+ffi = { version = "0.2.7", path = "sys", package = "matio-rs-sys" }
 paste = "1.0.15"
 thiserror = "2.0.18"
 derive = { version = "0.1.0", path = "derive", package = "matio-rs_derive" }

--- a/src/convert/maybefrom.rs
+++ b/src/convert/maybefrom.rs
@@ -346,7 +346,7 @@ impl<'a> MayBeFrom<&str> for Mat<'a> {
             ffi::Mat_VarCreate(
                 c_name.as_ptr(),
                 ffi::matio_classes_MAT_C_CHAR,
-                ffi::matio_types_MAT_T_UINT8,
+                ffi::matio_types_MAT_T_UTF8,
                 2,
                 dims.as_mut_ptr(),
                 data.as_ptr() as *mut std::ffi::c_void,
@@ -396,7 +396,7 @@ impl<'a> MayBeFrom<&[&str]> for Mat<'a> {
                 let matvar_t = ffi::Mat_VarCreate(
                     std::ptr::null_mut(),
                     ffi::matio_classes_MAT_C_CHAR,
-                    ffi::matio_types_MAT_T_UINT8,
+                    ffi::matio_types_MAT_T_UTF8,
                     2,
                     dims.as_mut_ptr(),
                     s.as_ptr() as *mut std::ffi::c_void,

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matio-rs-sys"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 authors = ["Rod Conan <rconan@gmto.org>"]
 license = "MIT"


### PR DESCRIPTION
I noticed that MAT files I have been creating over the last few days and which work properly with the MATLAB 2017, do not work with the MATLAB 2024b/2025b.

Seems like previous MATLAB versions (pre-2020 from what I found) do not care about proper character array validation, while [MAT file specification](https://www.mathworks.com/help/pdf_doc/matlab/matfile_format.pdf) states that:

> For character data that is not Unicode encoded, the Data Type part of the Tag field should be set to miUINT16.

So, I would like to propose the change that properly encodes character array data as UTF-8. Checked on MATLAB 2017b and 2025b - both are happy with the updated MAT files I supplied to them.

Previously, `load('file.mat')` with MATLAB 2017b worked fine while MATLAB 2024b/2025b produced the following error:
```
Error using load
Cannot read file file.mat.
```

I also updated the `matio` submodule to the version 1.5.30 because there were number of fixes related to character arrays:

```
- v1.5.23 — UTF-8 char array creation regression fix (the main culprit for R2020b+ rejection)
- v1.5.27 — Unicode filename support on Windows
- v1.5.28 — MAT_T_UINT8 char array write fix for compressed v5
- v1.5.30 — Mat_VarCreateStruct2 (CVE-2025-50343 fix)
```